### PR TITLE
Fix gg.cmd name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **easiest and recommended way** to use portable-git is through [gg](https://
 built-in as the `git` command. Run:
 
 ```bash
-gg git
+gg.cmd git
 ```
 
 More detailed (Linux):


### PR DESCRIPTION
I would say, that `gg.cmd` is always with `.cmd` suffix, isn't it?

(Otherwise, it could be mixed-up with [`gg`](https://github.com/gg-scm/gg))